### PR TITLE
ENH: Add the logic to use galvo_shutter

### DIFF
--- a/startup/11-shutters.py
+++ b/startup/11-shutters.py
@@ -52,6 +52,8 @@ class XFPGalvoShutter(Device):
         return st
 
     def stop(self, success):
+        # MR: commenting out on 10/30/2018 for manual control of the shutters (see #10).
+        '''
         import time
         prev_st = self._set_st
         if prev_st is not None:
@@ -61,6 +63,8 @@ class XFPGalvoShutter(Device):
         st = self.set('Close')
         while not st.done:
             time.sleep(.5)
+        '''
+        pass
 
     def resume(self):
         import time
@@ -84,9 +88,14 @@ class XFPGalvoShutter(Device):
         self.read_attrs = ['status']
 
 
+# MR: get rid of the stop() method on 10/30/2018 for manual control of the shutters (see #10).
+class TwoButtonShutterXFP(TwoButtonShutter):
+    def stop(self):
+        pass
 
-pre_shutter = TwoButtonShutter('XF:17BMA-EPS{Sh:1}', name='shutter')
+
+pre_shutter = TwoButtonShutterXFP('XF:17BMA-EPS{Sh:1}', name='shutter')
 shutter = pre_shutter
-pps_shutter = TwoButtonShutter('XF:17BM-PPS{Sh:FE}', name='pps_shutter')
+pps_shutter = TwoButtonShutterXFP('XF:17BM-PPS{Sh:FE}', name='pps_shutter')
 galvo_shutter = XFPGalvoShutter('XF:17BM-ES{Gon:1-Sht}', name='galvo_shutter')
 

--- a/startup/11-shutters.py
+++ b/startup/11-shutters.py
@@ -53,17 +53,15 @@ class XFPGalvoShutter(Device):
 
     def stop(self, success):
         # MR: commenting out on 10/30/2018 for manual control of the shutters (see #10).
-        '''
-        import time
-        prev_st = self._set_st
-        if prev_st is not None:
-            while not prev_st.done:
-                time.sleep(.1)
-        self._was_open = (self.open_val == self.status.get())
-        st = self.set('Close')
-        while not st.done:
-            time.sleep(.5)
-        '''
+        # import time
+        # prev_st = self._set_st
+        # if prev_st is not None:
+        #     while not prev_st.done:
+        #         time.sleep(.1)
+        # self._was_open = (self.open_val == self.status.get())
+        # st = self.set('Close')
+        # while not st.done:
+        #     time.sleep(.5)
         pass
 
     def resume(self):

--- a/startup/97-align-ht.py
+++ b/startup/97-align-ht.py
@@ -144,11 +144,9 @@ def _align_ht(dir_name, mtr,
     yield from bps.mv(dg, 600)  # generate 600-seconds pulse
     yield from bps.mv(dg.fire, 1)
 
+    yield from bps.mv(pre_shutter, 'Open')
     if use_galvo_shutter:
-        yield from bps.mv(pre_shutter, 'Open')
         yield from bps.mv(galvo_shutter, 'Open')
-    else:
-        yield from bps.mv(pre_shutter, 'Open')
 
     uid = yield from bpp.subs_wrapper(
             bp.scan([det],
@@ -161,11 +159,9 @@ def _align_ht(dir_name, mtr,
     ax.set_title(f'COM: {ps.com:.2f} mm  FWHM: {ps.fwhm:.2f} mm')
 
     
+    yield from bps.mv(pre_shutter, 'Close')
     if use_galvo_shutter:
-        yield from bps.mv(pre_shutter, 'Close')
         yield from bps.mv(galvo_shutter, 'Close')
-    else:
-        yield from bps.mv(pre_shutter, 'Close')
 
     yield from bps.mv(dg, 0)  # set delay to 0 (causes interruption of the current pulse)
 

--- a/startup/99-gui-ht.py
+++ b/startup/99-gui-ht.py
@@ -721,8 +721,9 @@ class XFPSampleSelector:
                 if not mode.test_mode:
                     if pps_shutter.status.get() == 'Not Open':
                         raise Exception(f'{pps_shutter.name} must be open to finish the scan')
-                    if pre_shutter.status.get() == 'Not Open' and not self.checkbox_shutter.isChecked() :
-                        raise Exception(f'{pre_shutter.name} must be open to finish the scan')
+                    if selected_shutter:
+                        if selected_shutter.read()[f'{selected_shutter.name}_status']['value'] in ['Not Open', 'Closed']:
+                            raise Exception(f'{selected_shutter.name} must be open to finish the scan')
 
                 if selected_shutter:
                     shutter_per_slot = True

--- a/startup/99-gui-ht.py
+++ b/startup/99-gui-ht.py
@@ -608,6 +608,14 @@ class XFPSampleSelector:
     def align_ht(self):
         self.button_align.setDisabled(True)
         kwargs = {'det': ALIGN_DETS[self.dets_combo.currentText()]}
+
+        # Pass a flag if galvo_shutter is selected:
+        selected_shutter_name, selected_shutter = self.get_selected_shutter()
+        if selected_shutter_name == 'GalvoShutter':
+            kwargs['use_galvo_shutter'] = True
+        else:
+            kwargs['use_galvo_shutter'] = False
+
         if self._manual_align_is_checked():
             kwargs['x_start'] = self.aligning_x.value()
             kwargs['y_start'] = self.aligning_y.value()


### PR DESCRIPTION
WIP: Under testing at the beamline.
- [x] Fix the issue with opened shutter while moving.
- [x] Pass the shutter in `def align_ht(self)`.
- [x] Integrate the galvo-shutter into the scanning logic.