### PR TITLE
ENH: properly identify the profile dir in IPython

### DIFF
--- a/startup/00-base.py
+++ b/startup/00-base.py
@@ -22,8 +22,7 @@ bec = BestEffortCallback()
 _time_fmtstr = '%Y-%m-%d %H:%M:%S'
 
 # Set ipython startup dir variable (used in 97 and 99):
-PROFILE_STARTUP_PATH = Path(f"{os.environ['HOME']}/.ipython/profile_collection/startup")
+PROFILE_STARTUP_PATH = Path(get_ipython().profile_dir.startup_dir)
 
 def xfp_print(string, stdout=sys.stdout, flush=True):
     print(string, file=stdout, flush=flush)
-


### PR DESCRIPTION
Based on findings for [QAS](https://github.com/NSLS-II-QAS/profile_collection/pull/4/files#diff-3c9608b12e0317fff31141238965cccfR67). It will properly find the profile startup dir even if the profile is renamed.