### PR TITLE
Fix profile issues

### DIFF
--- a/startup/10-motors.py
+++ b/startup/10-motors.py
@@ -312,7 +312,10 @@ quad = QuadEM('XF:17BM-BI{EM:1}', name='quad',
 
 pin_diode = QuadEM('XF:17BM-BI{EM:1}', name='pin_diode')
 
-diode = QuadEM('XF:17BM-BI{EM:BPM1}Current4:MeanValue_RBV', name = 'diode')
+# MR20190913: this 'diode' object below is misconfigured and causes a malformed
+# PV names for QuadEM devices in 15-electrometer.py.
+# See https://github.com/NSLS-II-XFP/profile_collection/pull/15 for details.
+# diode = QuadEM('XF:17BM-BI{EM:BPM1}Current4:MeanValue_RBV', name = 'diode')
 
 class ModXY_CF(Device):
     x = Cpt(EpicsMotor, 'X}Mtr')

--- a/startup/15-electrometer.py
+++ b/startup/15-electrometer.py
@@ -57,4 +57,3 @@ qem1 = XFPQuadEM("XF:17BM-BI{EM:1}EM180:", name="qem1")
 # qem2 = XFPQuadEM("XF:17BM-BI{EM:BPM1}", name='qem2')
 for det in [qem1]:
     det.read_attrs = ['current3', 'current3.mean_value']
-_

--- a/startup/99-gui-ht.py
+++ b/startup/99-gui-ht.py
@@ -118,7 +118,8 @@ class ColumnWidget:
             self.le.setText(str(self.data['name']))
             self.notes.setText(str(self.data['notes']))
             self.sb.setValue(float(self.data['exposure']))
-            self.filter_combo.setCurrentIndex(self.data['filter'])
+            if self.data['filter'] is not None:
+                self.filter_combo.setCurrentIndex(self.data['filter'])
         self.tooltip_update()
 
     def input_dialog(self):


### PR DESCRIPTION
Fix profile issues:
- [x] `None` value (see https://dev.azure.com/nsls2/profile_collections/_build/results?buildId=59)
- [ ] caproto client failure on quadem PVs (https://dev.azure.com/nsls2/profile_collections/_build/results?buildId=62)

```py

CaprotoTimeoutError‌: &lt;PV name=&#x27;XF:17BM-BI{EM:1}EM180:Current1:PluginType_RBV&#x27; priority=0 (searching....)&gt; could not connect within 1.0-second timeout.‌
Exception in thread retry:
Traceback (most recent call last):
  File "/home/vsts/mc/envs/collection-2019C3.0.1/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/home/vsts/mc/envs/collection-2019C3.0.1/lib/python3.7/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/home/vsts/mc/envs/collection-2019C3.0.1/lib/python3.7/site-packages/caproto/threading/client.py", line 858, in _retry_unanswered_searches
    SEARCH_MAX_DATAGRAM_BYTES - len(version_req)):
  File "/home/vsts/mc/envs/collection-2019C3.0.1/lib/python3.7/site-packages/caproto/_utils.py", line 772, in batch_requests
    for command in request_iter:
  File "/home/vsts/mc/envs/collection-2019C3.0.1/lib/python3.7/site-packages/caproto/threading/client.py", line 830, in _construct_search_requests
    ca.DEFAULT_PROTOCOL_VERSION)
  File "/home/vsts/mc/envs/collection-2019C3.0.1/lib/python3.7/site-packages/caproto/_commands.py", line 607, in __init__
    ''.format(MAX_RECORD_LENGTH, name, _len))
caproto._utils.CaprotoValueError: EPICS 3.14 imposes a 59-character limit on record names. The record 'XF:17BM-BI{EM:BPM1}Current4:MeanValue_RBVEM180:Current3:MeanValue_RBV' is 69 characters.
```