### PR TITLE
Add qem1_ts readout to xfp_fast_shutter exposure plan output

### DIFF
--- a/startup/15-electrometer.py
+++ b/startup/15-electrometer.py
@@ -73,6 +73,9 @@ class XFPQuadEM(QuadEMV33):
 
 
 qem1 = XFPQuadEM("XF:17BM-BI{EM:1}EM180:", name="qem1")
+qem1.kind = "normal"
+qem1.ts.kind = "normal"
+
 #TODO: add later when it's repared
 # qem2 = XFPQuadEM("XF:17BM-BI{EM:BPM1}", name='qem2')
 #TODO: read in current1, 2, 4 for qem1

--- a/startup/15-electrometer.py
+++ b/startup/15-electrometer.py
@@ -34,7 +34,7 @@ class TimeSeries(Device):
     acquire_mode = ADCpt(EpicsSignal, "TSAcquireMode", string=True, kind='config')
     acquiring = ADCpt(EpicsSignalRO, "TSAcquiring", kind='omitted')
 
-    time_axis = ADCpt(EpicsSignalRO, "TSTimeAxis", kind='config')
+    time_axis = ADCpt(EpicsSignalRO, "TSTimeAxis", kind='normal')
     read_rate = ADCpt(EpicsSignal, "TSRead.SCAN", string=True, kind='config')
     num_points = ADCpt(EpicsSignal, "TSNumPoints", kind='config')
     averaging_time = ADCpt(EpicsSignalWithRBV, "TSAveragingTime", kind="config")

--- a/startup/99-gui-ht.py
+++ b/startup/99-gui-ht.py
@@ -703,6 +703,7 @@ class XFPSampleSelector:
     def plan(self, file_name=None):
 
         def close_shutters():
+            yield from bps.mv(qem1.ts.acquire, 0)
             yield from bps.mv(pre_shutter, 'Close')
             yield from bps.mv(pps_shutter, 'Close')
             yield from bps.mv(ht.x, self.load_pos_x, ht.y, self.load_pos_y)  # load position
@@ -727,6 +728,8 @@ class XFPSampleSelector:
 
             if not mode.test_mode:
                 yield from bps.mv(pps_shutter, 'Open')
+            
+            yield from bps.mv(qem1.ts.acquire, 1)
 
             for gui_d in self.walk_values():
                 d = dict(base_md)
@@ -821,8 +824,11 @@ def xfp_plan_fast_shutter(d, shutter_per_slot):
 
     if shutter_per_slot:
         yield from bps.mv(pre_shutter, 'Close')
+    
+    #sleep of ca. 0.2 sec seems to be necessary for array data to be written
+    yield from bps.sleep(0.25)
 
-    return (yield from bp.count([ht.x, ht.y], md=d))
+    return (yield from bp.count([ht.x, ht.y, qem1.ts], md=d))
 
 try:
     HTgui.close()

--- a/startup/99-gui-ht.py
+++ b/startup/99-gui-ht.py
@@ -828,7 +828,7 @@ def xfp_plan_fast_shutter(d, shutter_per_slot):
     #sleep of ca. 0.2 sec seems to be necessary for array data to be written
     yield from bps.sleep(0.25)
 
-    return (yield from bp.count([ht.x, ht.y, qem1.ts], md=d))
+    return (yield from bp.count([ht.x, ht.y, qem1.ts.current1, qem1.ts.time_axis], md=d))
 
 try:
     HTgui.close()


### PR DESCRIPTION
Implements readout into databroker of a pin diode placed after Uniblitz shutter using time series plugin for qem1. This provides a physical measure of shutter opening time for each exposure.