### PR TITLE
HT - change preshutter to diode_shutter

### DIFF
--- a/startup/11-shutters.py
+++ b/startup/11-shutters.py
@@ -100,7 +100,7 @@ class DiodeShutter(Device):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.allowed_values = {'open': 1, 'close': 0}
+        self.allowed_values = {'Open': 1, 'Close': 0}
 
     def set(self, value):
         assert value in self.allowed_values.keys(), \

--- a/startup/97-align-ht.py
+++ b/startup/97-align-ht.py
@@ -148,7 +148,7 @@ def _align_ht(dir_name, mtr,
     # fire the fast shutter and wait for it to close again
     yield from bps.mv(dg, 600)  # generate 600-seconds pulse
     yield from bps.mv(dg.fire, 1)
-    # yield from bps.mv(shutter, 'Open')  # open the protective shutter
+    yield from bps.mv(shutter, 'Open')  # open the protective shutter
     yield from bps.mv(diode_shutter, 'Open')
 
     uid = yield from bpp.subs_wrapper(

--- a/startup/97-align-ht.py
+++ b/startup/97-align-ht.py
@@ -59,7 +59,8 @@ def align_ht(x_start=HT_X_START, y_start=HT_Y_START, md=None, offset=3, run=True
     _y_start = None
     if run:
         def close_shutters():
-            yield from bps.mv(shutter, 'Close')
+            yield from bps.mv(diode_shutter, 'Close')
+            # yield from bps.mv(shutter, 'Close')
             if not mode.test_mode:
                 yield from bps.mv(pps_shutter, 'Close')
             yield from bps.mv(ht.x, LOAD_POS_X, ht.y, LOAD_POS_Y)  # load position
@@ -147,7 +148,8 @@ def _align_ht(dir_name, mtr,
     # fire the fast shutter and wait for it to close again
     yield from bps.mv(dg, 600)  # generate 600-seconds pulse
     yield from bps.mv(dg.fire, 1)
-    yield from bps.mv(shutter, 'Open')  # open the protective shutter
+    # yield from bps.mv(shutter, 'Open')  # open the protective shutter
+    yield from bps.mv(diode_shutter, 'Open')
 
     uid = yield from bpp.subs_wrapper(
             bp.scan([det],
@@ -165,7 +167,8 @@ def _align_ht(dir_name, mtr,
 
     ax.set_title(f'COM: {ps.com:.2f} mm  FWHM: {ps.fwhm:.2f} mm')
 
-    yield from bps.mv(shutter, 'Close')  # close the protective shutter
+    yield from bps.mv(diode_shutter, 'Close')
+    #yield from bps.mv(shutter, 'Close')  # close the protective shutter
     yield from bps.mv(dg, 0)  # set delay to 0 (causes interruption of the current pulse)
 
     yield from bps.checkpoint()

--- a/startup/99-gui-ht.py
+++ b/startup/99-gui-ht.py
@@ -704,7 +704,8 @@ class XFPSampleSelector:
     def plan(self, file_name=None):
 
         def close_shutters():
-            yield from bps.mv(pre_shutter, 'Close')
+            yield from bps.mv(diode_shutter, 'Close')
+            # yield from bps.mv(pre_shutter, 'Close')
             yield from bps.mv(pps_shutter, 'Close')
             yield from bps.mv(ht.x, self.load_pos_x, ht.y, self.load_pos_y)  # load position
 
@@ -760,6 +761,8 @@ class XFPSampleSelector:
                 # Open it once, when the holder arrives to the first scanning point:
                 if pre_shutter.status.get() == 'Not Open' and not self.checkbox_shutter.isChecked():
                     yield from bps.mv(pre_shutter, 'Open')
+                if diode_shutter.status.get() == 'Not Open' and not self.checkbox_shutter.isChecked():
+                    yield from bps.mv(diode_shutter, 'Open')
 
                 # Check that the shutters are opened before collecting data:
                 if not mode.test_mode:
@@ -767,6 +770,8 @@ class XFPSampleSelector:
                         raise Exception(f'{pps_shutter.name} must be open to finish the scan')
                     if pre_shutter.status.get() == 'Not Open' and not self.checkbox_shutter.isChecked() :
                         raise Exception(f'{pre_shutter.name} must be open to finish the scan')
+                    if diode_shutter.status.get() == 'Not Open' and not self.checkbox_shutter.isChecked() :
+                        raise Exception(f'{diode_shutter.name} must be open to finish the scan')
 
                 uid = (yield from xfp_plan_fast_shutter(d,
                                                         shutter_per_slot=self.checkbox_shutter.isChecked()))
@@ -789,7 +794,8 @@ class XFPSampleSelector:
 
             # Close it once the walkthrough is done:
             if not self.checkbox_shutter.isChecked():
-                yield from bps.mv(shutter, 'Close')
+                # yield from bps.mv(shutter, 'Close')
+                yield from bps.mv(diode_shutter, 'Close')
 
             from bluesky.utils import FailedStatus
             try:
@@ -821,14 +827,16 @@ def xfp_plan_fast_shutter(d, shutter_per_slot):
     yield from bps.mv(dg, exp_time)
 
     if shutter_per_slot:
-        yield from bps.mv(pre_shutter, 'Open')
+        # yield from bps.mv(pre_shutter, 'Open')
+        yield from bps.mv(diode_shutter, 'Open')
 
     # fire the fast shutter and wait for it to close again
     yield from bps.mv(dg.fire, 1)
     yield from bps.sleep(exp_time*1.1)
 
     if shutter_per_slot:
-        yield from bps.mv(pre_shutter, 'Close')
+        # yield from bps.mv(pre_shutter, 'Close')
+        yield from bps.mv(diode_shutter, 'Close')
 
     return (yield from bp.count([ht.x, ht.y], md=d))
 

--- a/startup/99-gui-ht.py
+++ b/startup/99-gui-ht.py
@@ -759,7 +759,7 @@ class XFPSampleSelector:
                 self.re_controls.info_label.setText(motors_positions([ht.x, ht.y]))
 
                 # Open it once, when the holder arrives to the first scanning point:
-                if pre_shutter.status.get() == 'Not Open' and not self.checkbox_shutter.isChecked():
+                if pre_shutter.status.get() == 'Not Open':
                     yield from bps.mv(pre_shutter, 'Open')
                 if diode_shutter.status_closed.get() == 1 and not self.checkbox_shutter.isChecked():
                     yield from bps.mv(diode_shutter, 'Open')
@@ -768,7 +768,7 @@ class XFPSampleSelector:
                 if not mode.test_mode:
                     if pps_shutter.status.get() == 'Not Open':
                         raise Exception(f'{pps_shutter.name} must be open to finish the scan')
-                    if pre_shutter.status.get() == 'Not Open' and not self.checkbox_shutter.isChecked() :
+                    if pre_shutter.status.get() == 'Not Open':
                         raise Exception(f'{pre_shutter.name} must be open to finish the scan')
                     if diode_shutter.status_closed.get() == 1 and not self.checkbox_shutter.isChecked() :
                         raise Exception(f'{diode_shutter.name} must be open to finish the scan')

--- a/startup/99-gui-ht.py
+++ b/startup/99-gui-ht.py
@@ -761,7 +761,7 @@ class XFPSampleSelector:
                 # Open it once, when the holder arrives to the first scanning point:
                 if pre_shutter.status.get() == 'Not Open' and not self.checkbox_shutter.isChecked():
                     yield from bps.mv(pre_shutter, 'Open')
-                if diode_shutter.status.get() == 'Not Open' and not self.checkbox_shutter.isChecked():
+                if diode_shutter.status_closed.get() == 1 and not self.checkbox_shutter.isChecked():
                     yield from bps.mv(diode_shutter, 'Open')
 
                 # Check that the shutters are opened before collecting data:
@@ -770,7 +770,7 @@ class XFPSampleSelector:
                         raise Exception(f'{pps_shutter.name} must be open to finish the scan')
                     if pre_shutter.status.get() == 'Not Open' and not self.checkbox_shutter.isChecked() :
                         raise Exception(f'{pre_shutter.name} must be open to finish the scan')
-                    if diode_shutter.status.get() == 'Not Open' and not self.checkbox_shutter.isChecked() :
+                    if diode_shutter.status_closed.get() == 1 and not self.checkbox_shutter.isChecked() :
                         raise Exception(f'{diode_shutter.name} must be open to finish the scan')
 
                 uid = (yield from xfp_plan_fast_shutter(d,


### PR DESCRIPTION
Changes to use diode_shutter instead of pneumatic pre_shutter for the HT XFP workflow. Tested extensively by @erikfarquhar an @RobertSchaffer1 in the field.