### PR TITLE
Potential fix for bluesky widgets not updating during run

### DIFF
--- a/startup/91-gui-htfly.py
+++ b/startup/91-gui-htfly.py
@@ -2,8 +2,8 @@ import copy
 from enum import Enum
 
 import pandas as pd
+from matplotlib.backends.qt_compat import QtCore, QtGui, QtWidgets
 from ophyd import EpicsSignalRO
-from qtpy import QtCore, QtGui, QtWidgets
 
 
 class TestMode:


### PR DESCRIPTION
Using  matplotlib.backends.qt_compat should kick the GUI into a separate thread, similar to ht-gui